### PR TITLE
Endpoint / Request Refactor

### DIFF
--- a/Sources/Endpoints/Extensions/URLSession+Combine.swift
+++ b/Sources/Endpoints/Extensions/URLSession+Combine.swift
@@ -20,10 +20,10 @@ extension URLSession {
     ///   - endpoint: The Endpoint to use when creating the request
     ///   - request: The request data to insert into the Endpoint
     /// - Returns: A Publisher which fetches the Endpoints contents. Any failures when creating the request are sent as errors in the Publisher
-    public func endpointPublisher<T: RequestDataType>(in environment: EnvironmentType, for endpoint: Endpoint<T>, with request: T) -> AnyPublisher<T.Response, T.TaskError> where T.Response == Void {
+    public func endpointPublisher<T: RequestType>(in environment: EnvironmentType, for endpoint: Endpoint<T>, with request: T) -> AnyPublisher<T.Response, T.TaskError> where T.Response == Void {
         let urlRequest: URLRequest
         do {
-            urlRequest = try createUrlRequest(for: endpoint, in: environment, for: request)
+            urlRequest = try createUrlRequest(in: environment, for: request)
         } catch {
             return Fail(outputType: T.Response.self, failure: T.TaskError.endpointError(error as! EndpointError))
                 .eraseToAnyPublisher()
@@ -50,11 +50,11 @@ extension URLSession {
     ///   - endpoint: The Endpoint to use when creating the request
     ///   - request: The request data to insert into the Endpoint
     /// - Returns: A Publisher which fetches the Endpoints contents. Any failures when creating the request are sent as errors in the Publisher
-    public func endpointPublisher<T: RequestDataType>(in environment: EnvironmentType, for endpoint: Endpoint<T>, with request: T) -> AnyPublisher<T.Response, T.TaskError> where T.Response == Data {
+    public func endpointPublisher<T: RequestType>(in environment: EnvironmentType, for endpoint: Endpoint<T>, with request: T) -> AnyPublisher<T.Response, T.TaskError> where T.Response == Data {
 
         let urlRequest: URLRequest
         do {
-            urlRequest = try createUrlRequest(for: endpoint, in: environment, for: request)
+            urlRequest = try createUrlRequest(in: environment, for: request)
         } catch {
             return Fail(outputType: T.Response.self, failure: T.TaskError.endpointError(error as! EndpointError))
                 .eraseToAnyPublisher()
@@ -84,11 +84,11 @@ extension URLSession {
     ///   - endpoint: The Endpoint to use when creating the request
     ///   - request: The request data to insert into the Endpoint
     /// - Returns: A Publisher which fetches the Endpoints contents. Any failures when creating the request are sent as errors in the Publisher
-    public func endpointPublisher<T: RequestDataType>(in environment: EnvironmentType, for endpoint: Endpoint<T>, with request: T) -> AnyPublisher<T.Response, T.TaskError> where T.Response: Decodable {
+    public func endpointPublisher<T: RequestType>(in environment: EnvironmentType, for endpoint: Endpoint<T>, with request: T) -> AnyPublisher<T.Response, T.TaskError> where T.Response: Decodable {
 
         let urlRequest: URLRequest
         do {
-            urlRequest = try createUrlRequest(for: endpoint, in: environment, for: request)
+            urlRequest = try createUrlRequest(in: environment, for: request)
         } catch {
             return Fail(outputType: T.Response.self, failure: T.TaskError.endpointError(error as! EndpointError))
                 .eraseToAnyPublisher()


### PR DESCRIPTION
## Proposal

I'm playing around with where we put the `Endpoint` instance and am tempted to hang it off the `RequestType` (renamed from `RequestDataType`) as a static var. This helps tie some of the types together and allows the request instance itself to create the `URLRequest` with only an `EnvironmentType` passed in.

So usage would go from:

<details>
  <summary>Old Implementation of `RequestDataType` + `Endpoint`</summary>
  
### Declaration
```Swift
struct SimpleRequest: RequestDataType {
    struct Response: Decodable {
        let response1: String
    }

    struct PathComponents {
        let name: String
        let id: String
    }

    let pathComponents: PathComponents
}

enum Endpoints {
    static let simpleEndpoint: Endpoint<SimpleRequest> = Endpoint(
        method: .get,
        path: "user/\(path: \.name)/\(path: \.id)/profile"
    )
}
```

### Usage
```Swift
let task = try self.session.endpointTask(in: Environment.staging, for: Endpoints.simpleEndpoint, with: SimpleRequest(name: name, id: id)) { result in
    ...
}
task.resume()
```
</details>

<details>
  <summary>New Implementation of `RequestType` + `Endpoint`</summary>

### Declaration
```Swift
struct SimpleRequest: RequestType {
    static var endpoint: Endpoint<SimpleRequest> = Endpoint(
        method: .get,
        path: "user/\(path: \.name)/\(path: \.id)/profile"
    )

    struct Response: Decodable {
        let response1: String
    }

    struct PathComponents {
        let name: String
        let id: String
    }

    let pathComponents: PathComponents
}
```

### Usage
```Swift
let task = try self.session.endpointTask(in: Environment.staging, with: SimpleRequest(name: name, id: id)) { result in
    ...
}
task.resume()
```
</details>

## What Changed

- Renamed `RequestDataType` to `RequestType`
- Moved Endpoints into the `RequestType`
