### PR TITLE
Preliminary Offline Caching Support

### DIFF
--- a/Sources/Endpoints/Endpoint.swift
+++ b/Sources/Endpoints/Endpoint.swift
@@ -86,6 +86,15 @@ public protocol RequestType {
     static var endpoint: Endpoint<Self> { get }
 }
 
+///
+/// Adopted by `RequestType`s to indicate that the response is potentially cachable for offline use when internet is disconnected.
+///
+public protocol CacheableRequestType {
+
+    /// If `true`, `URLSession.endpointPublisher` attempts to satisfy failing requests using previously cached responses when device is offline
+    var isCacheable: Bool { get }
+}
+
 extension RequestType {
 
     /// Generates a `URLRequest` given the associated request value.


### PR DESCRIPTION
Adds a `CacheableRequestType` protocol such that when adopted by `RequestType` structs, instructs endpoint publisher to use data from cache for the request if device is offline.

This has only been implemented on the main variation of endpoint publisher:
```swift
public func endpointPublisher<T: RequestType>(in environment: EnvironmentType, with request: T) -> AnyPublisher<T.Response, T.TaskError> where T.Response: Decodable
```

In Acrylic, this causes Events to be cached for offline use:
```swift
extension GetEventsRequest: CacheableRequestType {
    var isCacheable: Bool { true }
}
```

#### Implementation Notes
The system automatically caches responses less than ~500K, so lines [138-139](https://github.com/velos/Endpoints/pull/12/commits/d1349116b86adfd058027152a8a48fa032c8550a#diff-7994a8f69f823f327b42aff193a0a550adcbfe110b2fbd2ba2138831d4a41a26R138-R139) are only necessary for large requests like `GetEventsRequest`.  The check in line [133](https://github.com/velos/Endpoints/pull/12/commits/d1349116b86adfd058027152a8a48fa032c8550a#diff-7994a8f69f823f327b42aff193a0a550adcbfe110b2fbd2ba2138831d4a41a26R133) ensures redundant writes to cache are avoided.

**Below**:  iPad in airplane mode, yet is able to show the Events and Explore tabs using cached data. Note that adding to cart still fails appropriately.

https://user-images.githubusercontent.com/5950250/134435254-558c0978-b4ee-4559-8cbd-a561d496b525.mov
