### PR TITLE
Fix setting Content-Type header field when client app already specifies it

### DIFF
--- a/Sources/Endpoints/Endpoint.swift
+++ b/Sources/Endpoints/Endpoint.swift
@@ -192,12 +192,12 @@ extension RequestType {
                 throw EndpointError.invalidBody(error)
             }
 
-            if headerItems["Content-Type"] == nil {
-                urlRequest.addValue("application/json", forHTTPHeaderField: "Content-Type")
+            if headerItems[Headers.contentType.name] == nil {
+                urlRequest.addValue("application/json", forHTTPHeaderField: Headers.contentType.name)
             }
         } else if !bodyFormItems.isEmpty {
             urlRequest.httpBody = bodyFormItems.formString.data(using: .utf8)
-            urlRequest.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+            urlRequest.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: Headers.contentType.name)
         }
 
         urlRequest = environment.requestProcessor(urlRequest)

--- a/Sources/Endpoints/Endpoint.swift
+++ b/Sources/Endpoints/Endpoint.swift
@@ -192,7 +192,9 @@ extension RequestType {
                 throw EndpointError.invalidBody(error)
             }
 
-            urlRequest.addValue("application/json", forHTTPHeaderField: "Content-Type")
+            if headerItems["Content-Type"] == nil {
+                urlRequest.addValue("application/json", forHTTPHeaderField: "Content-Type")
+            }
         } else if !bodyFormItems.isEmpty {
             urlRequest.httpBody = bodyFormItems.formString.data(using: .utf8)
             urlRequest.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")


### PR DESCRIPTION
Addresses a header collision issue when clients of Endpoints attempts to also set the "Content-Type" header field.