### PR TITLE
Fix for forced cast failure crash

### DIFF
--- a/Sources/Endpoints/Extensions/URLSession+Combine.swift
+++ b/Sources/Endpoints/Extensions/URLSession+Combine.swift
@@ -88,7 +88,7 @@ extension URLSession {
         do {
             urlRequest = try createUrlRequest(in: environment, for: request)
         } catch {
-            return Fail(outputType: T.Response.self, failure: T.TaskError.endpointError(error as! EndpointError))
+            return Fail(outputType: T.Response.self, failure: error as! EndpointTaskError)
                 .eraseToAnyPublisher()
         }
 


### PR DESCRIPTION
Crashes occurred because of a failure to cast an underlying error to an `EndpointError` when creating a URLRequest for an Endpoint:

UrlSession+Combine.swift, line 91:
Could not cast value of type 'Endpoints.EndpointTaskError<BECAUSENetworking.ApiErrorResponse>' (0x121811fa0) to 'Endpoints.EndpointError' (0x1041cad70).

It looks like the call to `createUrlRequest(in: environment, for: request)` can only throw an `EndpointTaskError` (aka `TaskError`), which can't be force cast to `EndpointError` as attempted on line 91.  The solution here seems to be to cast `error` directly to that type instead of trying to wrap it in another `EndpointTaskError`.  This PR will cause that error to be published instead of causing a crash.