### PR TITLE
Query Encoding Strategy

### DIFF
--- a/Sources/Endpoints/Endpoint+URLRequest.swift
+++ b/Sources/Endpoints/Endpoint+URLRequest.swift
@@ -85,9 +85,9 @@ extension Endpoint {
         case .custom(let encode):
             components.percentEncodedQuery = urlQueryItems
                 .compactMap(encode)
-                .compactMap { item in
-                    guard let value = item.value else { return nil }
-                    return item.name + "=" + value
+                .compactMap { (name, value) in
+                    guard let value else { return nil }
+                    return name + "=" + value
                 }
                 .joined(separator: "&")
         }

--- a/Sources/Endpoints/Endpoint+URLRequest.swift
+++ b/Sources/Endpoints/Endpoint+URLRequest.swift
@@ -79,6 +79,19 @@ extension Endpoint {
             components.queryItems = urlQueryItems
         }
 
+        switch Self.queryEncodingStrategy {
+        case .default:
+            break
+        case .custom(let encode):
+            components.percentEncodedQuery = urlQueryItems
+                .compactMap(encode)
+                .compactMap { item in
+                    guard let value = item.value else { return nil }
+                    return item.name + "=" + value
+                }
+                .joined(separator: "&")
+        }
+
         let baseUrl = environment.baseUrl
         guard let url = components.url(relativeTo: baseUrl) else {
             throw EndpointError.invalid(components: components, relativeTo: baseUrl)

--- a/Sources/Endpoints/Endpoint.swift
+++ b/Sources/Endpoints/Endpoint.swift
@@ -185,7 +185,7 @@ public extension Endpoint {
 
 public enum QueryEncodingStrategy {
     case `default`
-    case custom((URLQueryItem) -> URLQueryItem?)
+    case custom((URLQueryItem) -> (String, String?)?)
 }
 
 public struct Definition<T: Endpoint> {

--- a/Sources/Endpoints/Endpoint.swift
+++ b/Sources/Endpoints/Endpoint.swift
@@ -139,6 +139,9 @@ public protocol Endpoint {
 
     /// The decoder instance to use when decoding the associated ``Endpoint/Response`` type
     static var responseDecoder: ResponseDecoder { get }
+
+    /// A strategy for encoding query parameters. Defaults to `QueryEncodingStrategy.default`
+    static var queryEncodingStrategy: QueryEncodingStrategy { get }
 }
 
 public extension Endpoint where Body == EmptyCodable {
@@ -172,6 +175,17 @@ public extension Endpoint where BodyEncoder == JSONEncoder {
     static var bodyEncoder: BodyEncoder {
         return JSONEncoder()
     }
+}
+
+public extension Endpoint {
+    static var queryEncodingStrategy: QueryEncodingStrategy {
+        return .default
+    }
+}
+
+public enum QueryEncodingStrategy {
+    case `default`
+    case custom((URLQueryItem) -> URLQueryItem?)
 }
 
 public struct Definition<T: Endpoint> {

--- a/Tests/EndpointsTests/Endpoints/CustomEncodingEndpoint.swift
+++ b/Tests/EndpointsTests/Endpoints/CustomEncodingEndpoint.swift
@@ -1,0 +1,36 @@
+//
+//  CustomEncodingEndpoint.swift
+//  EndpointsTests
+//
+//  Created by Zac White on 9/26/24.
+//  Copyright © 2024 Velos Mobile LLC. All rights reserved.
+//
+
+import Endpoints
+import Foundation
+
+struct CustomEncodingEndpoint: Endpoint {
+    static let definition: Definition<CustomEncodingEndpoint> = Definition(
+        method: .get,
+        path: "/",
+        parameters: [
+            .query("key", path: \ParameterComponents.needsCustomEncoding)
+        ]
+    )
+
+    struct ParameterComponents {
+        let needsCustomEncoding: String
+    }
+
+    typealias Response = Void
+
+    let parameterComponents: ParameterComponents
+
+    static var queryEncodingStrategy: QueryEncodingStrategy {
+        .custom {
+            var characterSet = CharacterSet.urlQueryAllowed
+            characterSet.remove(charactersIn: "+")
+            return ($0.name, $0.value?.addingPercentEncoding(withAllowedCharacters: characterSet))
+        }
+    }
+}

--- a/Tests/EndpointsTests/Endpoints/UserEndpoint.swift
+++ b/Tests/EndpointsTests/Endpoints/UserEndpoint.swift
@@ -40,10 +40,7 @@ struct UserEndpoint: Endpoint {
         .custom {
             var characterSet = CharacterSet.urlQueryAllowed
             characterSet.remove(charactersIn: "+")
-            return URLQueryItem(
-                name: $0.name,
-                value: $0.value?.addingPercentEncoding(withAllowedCharacters: characterSet)
-            )
+            return ($0.name, $0.value?.addingPercentEncoding(withAllowedCharacters: characterSet))
         }
     }
 

--- a/Tests/EndpointsTests/Endpoints/UserEndpoint.swift
+++ b/Tests/EndpointsTests/Endpoints/UserEndpoint.swift
@@ -36,6 +36,17 @@ struct UserEndpoint: Endpoint {
         ]
     )
 
+    static var queryEncodingStrategy: QueryEncodingStrategy {
+        .custom {
+            var characterSet = CharacterSet.urlQueryAllowed
+            characterSet.remove(charactersIn: "+")
+            return URLQueryItem(
+                name: $0.name,
+                value: $0.value?.addingPercentEncoding(withAllowedCharacters: characterSet)
+            )
+        }
+    }
+
     typealias Response = Void
 
     struct PathComponents {

--- a/Tests/EndpointsTests/EndpointsTests.swift
+++ b/Tests/EndpointsTests/EndpointsTests.swift
@@ -66,7 +66,7 @@ class EndpointsTests: XCTestCase {
         let request = try UserEndpoint(
             pathComponents: .init(userId: "3"),
             parameterComponents: .init(
-                string: "test:of:thing%asdf",
+                string: "test:of:+thing%asdf",
                 date: Date(),
                 double: 2.3,
                 int: 42,
@@ -81,7 +81,7 @@ class EndpointsTests: XCTestCase {
 
         XCTAssertEqual(request.httpMethod, "GET")
         XCTAssertEqual(request.url?.path, "/hey/3")
-        XCTAssertEqual(request.url?.query, "string=test:of:thing%25asdf&hard_coded_query=true")
+        XCTAssertEqual(request.url?.query, "string=test:of:%2Bthing%25asdf&hard_coded_query=true")
 
         XCTAssertEqual(request.value(forHTTPHeaderField: "HEADER_TYPE"), "test")
         XCTAssertEqual(request.value(forHTTPHeaderField: "HARD_CODED_HEADER"), "test2")
@@ -90,7 +90,7 @@ class EndpointsTests: XCTestCase {
 
         XCTAssertNotNil(request.httpBody)
         XCTAssertTrue(
-            String(data: request.httpBody ?? Data(), encoding: .utf8)?.contains("string=test%3Aof%3Athing%25asdf") ?? false
+            String(data: request.httpBody ?? Data(), encoding: .utf8)?.contains("string=test%3Aof%3A+thing%25asdf") ?? false
         )
         XCTAssertFalse(
             String(data: request.httpBody ?? Data(), encoding: .utf8)?.contains("optional_string") ?? true

--- a/Tests/EndpointsTests/EndpointsTests.swift
+++ b/Tests/EndpointsTests/EndpointsTests.swift
@@ -61,6 +61,14 @@ class EndpointsTests: XCTestCase {
         XCTAssertEqual(request.httpMethod, "POST")
     }
 
+    func testCustomParameterEncoding() throws {
+        let request = try CustomEncodingEndpoint(
+            parameterComponents: .init(needsCustomEncoding: "++++")
+        ).urlRequest(in: Environment.test)
+
+        XCTAssertEqual(request.url?.query, "key=%2B%2B%2B%2B")
+    }
+
     func testParameterEndpoint() throws {
 
         let request = try UserEndpoint(


### PR DESCRIPTION
## Description

* Added a `queryEncodingStrategy` static property that can be overridden on each Endpoint. This allows for manual encoding of query values (or keys if required, but usually that not a use-case).